### PR TITLE
shorten variant listing significantly

### DIFF
--- a/meltdown.c
+++ b/meltdown.c
@@ -169,7 +169,8 @@ int readbyte(int fd, unsigned long addr)
 
 #ifdef DEBUG
 	for (i = 0; i < VARIANTS_READ; i++)
-		printf("addr %lx hist[%x] = %d\n", addr, i, hist[i]);
+		if (hist[i] > 0)
+			printf("addr %lx hist[%x] = %d\n", addr, i, hist[i]);
 #endif
 
 	for (i = 1; i < VARIANTS_READ; i++) {


### PR DESCRIPTION
With `make CFLAGS='-DDEBUG'`, the listing of "variant bytes read" is very long (and mostly includes zeroes in the case of a vulnerable system). This patch avoids printing the values which were never read.