### PR TITLE
Add mfence instruction before speculation

### DIFF
--- a/meltdown.c
+++ b/meltdown.c
@@ -143,6 +143,8 @@ int readbyte(int fd, unsigned long addr)
 
 		clflush_target();
 
+		_mm_mfence();
+
 		speculate(addr);
 		check();
 	}


### PR DESCRIPTION
I ran the exploit on an i7-4500U CPU, which it (correctly) reported as vulnerable. However, the scores averaged only about 200/1000 and a few times they were low enough to report the machine as not vulnerable. I tried adding an mfence instruction before the speculative accesses, with the idea of ensuring that the kernel data is cached before accessing it.  With this change the exploit runs with (near-)perfect scores (i.e. 995+/1000 almost every time) on my machine. Given what I know about x86_64's consistency model, I wouldn't expect this change to make a difference but perhaps there are more subtle things going on with respect to the cache.

So this seems to make the exploit more reliable. Do you see any reason not to make this change?

Also, if you happen to know why this has such a dramatic effect I'd be interested in that.